### PR TITLE
🐞 fix: 拡張子除去

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,9 @@ export async function convertImage(inputPath, outputDir, quality, spImageWidth) 
         promises.push(processDirectory(fullInputPath, subOutputPath, newRelativePath));
       } else {
         // ファイルの場合、画像変換を実行
-        const ext = path.extname(file).toLowerCase();
-        const baseName = path.basename(file, ext);
+        const originalExt = path.extname(file); // 元の拡張子（大文字小文字そのまま）
+        const ext = originalExt.toLowerCase(); // 小文字化した拡張子
+        const baseName = path.basename(file, originalExt); // 元の拡張子で取り除く
 
         // 画像ファイルかチェック
         if (!['.jpg', '.jpeg', '.png', '.webp', '.avif', '.tiff', '.bmp'].includes(ext)) {


### PR DESCRIPTION
This pull request makes a small but important change to the way file extensions are handled during image conversion. The code now preserves the original case of the file extension when extracting the base name, which can help ensure more accurate file processing, especially on case-sensitive file systems.

- Improved file extension handling in `convertImage`: The original file extension (`originalExt`) is now used when extracting the base name with `path.basename`, preserving the exact case of the extension from the input file. (`index.js`, [index.jsL40-R42](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L40-R42))